### PR TITLE
removed password from posmeta and login fb user directly

### DIFF
--- a/controllers/login.php
+++ b/controllers/login.php
@@ -154,19 +154,11 @@ Class ajax_login_register_Login Extends AjaxLogin {
 
                 $user_id = $user_obj->ID;
 
-                // Log our FB user in
-                $password = get_user_meta( $user_id, '_random', true );
+	            wp_set_auth_cookie( $user_id, true );
 
-                $logged_in = $this->login_submit( $user_obj->user_login, $password, false );
-
-                if ( $logged_in == true ){
-                    $status = $this->status('success_login');
-                } else {
-                    $status = $this->status('invalid_username');
-                }
+	            $status = $this->status('success_login');
 
             } else {
-
                 $status = $this->status('invalid_username');
             }
         }

--- a/controllers/register.php
+++ b/controllers/register.php
@@ -139,8 +139,6 @@ Class ajax_login_register_Register Extends AjaxLogin {
 
         } else {
 
-            // Store random password as user meta
-            add_user_meta( $user_id, '_random', $user_pass );
             $user_obj = get_user_by( 'id', $user_id );
 
         }


### PR DESCRIPTION
Hi Zane, I think is not a good idea to store plain password in the postmeta table. Anyone with access to the database could login that user.

I changed the code a bit, as the user logs with facebook we are able to retrieve user_id, then we can directly login the user without the need of the password.

Anyway try it yourself and let me know. This is how Wordpress Social Login auths the user and my tests seems to work fine.