### PR TITLE
Added jQuery events that can be used to hook up third party tools.

### DIFF
--- a/assets/login.js
+++ b/assets/login.js
@@ -19,6 +19,8 @@ $document.ready(function( $ ){
 
         $this.find( form_fields ).attr('disabled','disabled');
 
+        $(document).trigger('zm-before-login-ajax');
+
         $.ajax({
             global: false,
             data: "action=login_submit&" + serialized_form + "&security=" + $this.data('zm_alr_login_security') + "&" + google_recaptcha,
@@ -29,7 +31,7 @@ $document.ready(function( $ ){
                 ajax_login_register_show_message( $this, msg );
                 $this.find( form_fields ).removeAttr('disabled');
                 zMAjaxLoginRegister.reload( msg.redirect_url );
-
+                $(document).trigger('zm-after-login-ajax');
             }
         });
     });

--- a/assets/register.js
+++ b/assets/register.js
@@ -71,6 +71,8 @@ $document.ready(function( $ ){
             }
         }
 
+        $(document).trigger('zm-before-register-ajax');
+
         $.ajax({
             global: false,
             data: "action=setup_new_user&" + serialized_form + "&security=" + $this.data('zm_alr_register_security') + "&" + google_recaptcha,
@@ -81,6 +83,7 @@ $document.ready(function( $ ){
                 ajax_login_register_show_message( $this, msg );
                 $this.find( form_fields ).removeAttr('disabled');
                 zMAjaxLoginRegister.reload( msg.redirect_url );
+                $(document).trigger('zm-after-register-ajax');
             }
         });
 

--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -168,6 +168,15 @@ $document.ready(function( $ ){
 
     window.ajax_login_register_show_message = function( form_obj, msg ) {
         if ( msg.code === 'success_login' || msg.code === 'success_registration' ){
+
+            // Trigger an event that allows other plugins to know when the user
+            // is successfully logged in/registered.
+            if ( msg.code === 'success_login' ) {
+                jQuery(document).trigger('zm-login-success', [form_obj, msg]);
+            } else {
+                jQuery(document).trigger('zm-register-success', [form_obj, msg]);
+            }
+
             jQuery('.ajax-login-register-msg-target', form_obj)
                 .addClass( msg.cssClass )
                 .stop()


### PR DESCRIPTION
Hi! I've added a few hooks to improve the integration on the JS side.

Many others could be added, but I've limited them to the Use Case I was trying to solve, which was adding a loading overlay and then hide the form (and the overlay) on success.

The way I use it is as follows:

```
    // Hooks to ajax login/register.
    jQuery(document).on("zm-register-success zm-login-success", function() {
        console.info("Login/Register success.");
    });

    jQuery(document).on("zm-before-register-ajax zm-before-login-ajax", function() {
        console.info("Before Login/Register.");
    });

    jQuery(document).on("zm-after-register-ajax zm-after-login-ajax", function() {
        console.info("After Login/Register.");
    });
```

I hope you find it useful and hopefully integrate it.

Thanks for your work!